### PR TITLE
[PTFE-105] 🐛 Fix AWS runner-manager tags problem in the conf file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,4 @@ RUN poetry config virtualenvs.create false && \
 
 COPY . /app/
 
-RUN useradd -r -u 1000 runner-manager \
-    && chown -R runner-manager /app
-USER runner-manager
-
 CMD ["uvicorn", "srcs.web.app:app", "--host", "0.0.0.0", "--port", "80"]

--- a/srcs/runners_manager/vm_creation/aws/AwsManager.py
+++ b/srcs/runners_manager/vm_creation/aws/AwsManager.py
@@ -31,6 +31,7 @@ class AwsManager(CloudManager):
         )
         self.tags = settings.get("tags")
         self.ec2 = boto3.client("ec2")
+        logger.debug('AWS init, configured with tags: {}'.format(self.tags))
 
     def delete_existing_runner(self, runner: Runner):
         """Delete an old runner instance from AWS if it exists."""


### PR DESCRIPTION
Over the past few weeks, we've encountered an issue with the AWS runner-manager. Specifically, in the code of the `runner-manager` repository, we were unable to dynamically set the tags and had to hardcode them in the code. As a result, we are working to address this issue with this pull request.