### PR TITLE
PTFE-456: break loop when demanding new runner

### DIFF
--- a/srcs/runners_manager/runner/RunnerManager.py
+++ b/srcs/runners_manager/runner/RunnerManager.py
@@ -77,8 +77,12 @@ class RunnerManager(object):
         It won't create a Runner if we are already at the maximum we want.
         In the case the max is set at 0 we don't have a maximum.
         """
+        offline_runners = len(self.filter_runners(lambda r: r.has_run))
+        online_runners = len(self.filter_runners(lambda r: r.is_online))
+        creating_runners = len(self.filter_runners(lambda r: r.is_creating))
         if 0 < self.vm_type.quantity["max"] <= len(self.runners):
             logger.info("Runner not created, already to much")
+            logger.info(f"{online_runners} runners online, {creating_runners} creating, {offline_runners} offline")
             return
 
         if not self.redis.get_manager_running():

--- a/srcs/runners_manager/runner/RunnerManager.py
+++ b/srcs/runners_manager/runner/RunnerManager.py
@@ -77,9 +77,9 @@ class RunnerManager(object):
         It won't create a Runner if we are already at the maximum we want.
         In the case the max is set at 0 we don't have a maximum.
         """
-        offline_runners = len(self.filter_runners(lambda r: r.has_run))
-        online_runners = len(self.filter_runners(lambda r: r.is_online))
-        creating_runners = len(self.filter_runners(lambda r: r.is_creating))
+        offline_runners = len(self.filter_runners(lambda runner: runner.has_run))
+        online_runners = len(self.filter_runners(lambda runner: runner.is_online))
+        creating_runners = len(self.filter_runners(lambda runner: runner.is_creating))
         if 0 < self.vm_type.quantity["max"] <= len(self.runners):
             logger.info("Runner not created, already to much")
             logger.info(f"{online_runners} runners online, {creating_runners} creating, {offline_runners} offline")


### PR DESCRIPTION
When a new runner is required the function need_new_runner is stucked in a while loop until a runner is created. We noticed if the max is reached we get a lot of error message. So i use and if condition instead of while. In any case the manage_runners function that calls the need_runner function is ran every 2 mins so this would atleast reduce the number of log entries