### PR TITLE
PTFE-610: bugfix rollback spot instances

### DIFF
--- a/srcs/runners_manager/runner/RunnerManager.py
+++ b/srcs/runners_manager/runner/RunnerManager.py
@@ -82,7 +82,9 @@ class RunnerManager(object):
         creating_runners = len(self.filter_runners(lambda runner: runner.is_creating))
         if 0 < self.vm_type.quantity["max"] <= len(self.runners):
             logger.info("Runner not created, already to much")
-            logger.info(f"{online_runners} runners online, {creating_runners} creating, {offline_runners} offline")
+            logger.info(f"{online_runners} runners online, "
+                f"{creating_runners} creating, "
+                f"{offline_runners} offline")
             return
 
         if not self.redis.get_manager_running():

--- a/srcs/runners_manager/vm_creation/gcloud/GcloudManager.py
+++ b/srcs/runners_manager/vm_creation/gcloud/GcloudManager.py
@@ -120,7 +120,7 @@ class GcloudManager(CloudManager):
         automatic_restart = True
         provisioning_model = "STANDARD"
         instance_termination_action = "DEFAULT"
-        preemptible = bool(runner.vm_type.config.get("spot", False))
+        preemptible = str(runner.vm_type.config.get("spot", "")).lower() == "true"
         if preemptible:
             provisioning_model = "SPOT"
             automatic_restart = False

--- a/srcs/runners_manager/vm_creation/gcloud/GcloudManager.py
+++ b/srcs/runners_manager/vm_creation/gcloud/GcloudManager.py
@@ -1,6 +1,7 @@
 import logging
 import re
 
+from distutils.util import strtobool
 from google.api_core.extended_operation import ExtendedOperation
 from google.cloud.compute import AccessConfig
 from google.cloud.compute import AdvancedMachineFeatures
@@ -120,7 +121,7 @@ class GcloudManager(CloudManager):
         automatic_restart = True
         provisioning_model = "STANDARD"
         instance_termination_action = "DEFAULT"
-        preemptible = str(runner.vm_type.config.get("spot", "")).lower() == "true"
+        preemptible = strtobool(runner.vm_type.config.get("spot", False))
         if preemptible:
             provisioning_model = "SPOT"
             automatic_restart = False


### PR DESCRIPTION
Spot instances are still being spawn. This is because the check that obtains the value of the spot key does not work properly. It always returns true. This is a fix.