### PR TITLE
PTFE-711 disable chekcov

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,18 +20,12 @@ lint:
     - yamllint@1.32.0
     - pyright@1.1.318
     - hadolint@2.12.0
-    - checkov@2.3.75
   disabled:
+    - checkov
     - bandit
     - osv-scanner
     - trivy
     - terrascan
-  triggers:
-    - linters: [checkov]
-      paths:
-        - .github/workflows
-      targets:
-        - .github/workflows
 runtimes:
   enabled:
     - node@18.12.1


### PR DESCRIPTION
After failing to configure checkov's execution on GitHub Actions workflows only and other configuration needed. Deactivating it for now. 