### PR TITLE
Fix deployment tests BadRequest failure 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,8 @@
         "GitHub.copilot",
         "bierner.markdown-mermaid",
         "tamasfe.even-better-toml",
-        "github.vscode-github-actions"
+        "github.vscode-github-actions",
+        "ms-kubernetes-tools.vscode-kubernetes-tools"
       ],
       "settings": {
         "python.analysis.typeCheckingMode": "basic",

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,32 +2,32 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: /
     schedule:
       interval: daily
     commit-message:
-      prefix: "github-actions"
-      include: "scope"
+      prefix: github-actions
+      include: scope
     labels:
-      - "github-actions"
-      - "dependencies"
+      - github-actions
+      - dependencies
   - package-ecosystem: docker
-    directory: "/"
+    directory: /
     schedule:
       interval: daily
     commit-message:
-      prefix: "docker"
-      include: "scope"
+      prefix: docker
+      include: scope
     labels:
-      - "docker"
-      - "dependencies"
+      - docker
+      - dependencies
   - package-ecosystem: pip
-    directory: "/"
+    directory: /
     schedule:
       interval: daily
     commit-message:
-      prefix: "pip"
-      include: "scope"
+      prefix: pip
+      include: scope
     labels:
-      - "pip"
-      - "dependencies"
+      - pip
+      - dependencies

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -2,23 +2,23 @@
 name: codeQL
 
 on:
-    push:
-      branches: [main]
-    pull_request:
-      branches: [main]
-    workflow_dispatch: {}
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
 
 jobs:
-    analyze:
-      name: Static analysis with CodeQL
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v3
-        - name: Initialize CodeQL
-          uses: github/codeql-action/init@v2
-          with:
-            languages: python
+  analyze:
+    name: Static analysis with CodeQL
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: python
 
-        - name: Build and analyze
-          uses: github/codeql-action/analyze@v2
+      - name: Build and analyze
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/test-deployment.yaml
+++ b/.github/workflows/test-deployment.yaml
@@ -1,7 +1,6 @@
 ---
 name: test-deployment
 
-
 on: pull_request
 
 permissions:

--- a/.github/workflows/test-deployment.yaml
+++ b/.github/workflows/test-deployment.yaml
@@ -23,19 +23,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: helm/kind-action@v1
       - name: Edit the runner-manager image
-        working-directory: tests
-        run: |
-          cat <<EOF > kustomization.yaml
-          apiVersion: kustomize.config.k8s.io/v1beta1
-          kind: Kustomization
-          images:
-            - name: ghcr.io/scality/runner-manager
-              newTag: ${{ github.sha }}
-          resources:
-            - ../manifests
-          EOF
+        working-directory: manifests
+        run: kustomize edit set image ghcr.io/scality/runner-manager:${{ github.sha }}
       - name: Deploy runner-manager
-        run: kustomize build tests/ | kubectl apply -f -
+        run: kubectl apply -k manifests
       - name: Check if deployment is ready
         run: |
           kubectl rollout status statefulset redis --timeout=90s

--- a/manifests/base/redis/kustomization.yaml
+++ b/manifests/base/redis/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-
 commonLabels:
   app.kubernetes.io/instance: redis
   app.kubernetes.io/name: redis

--- a/manifests/base/redis/statefulset.yaml
+++ b/manifests/base/redis/statefulset.yaml
@@ -12,7 +12,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: redis
-          image: "redis/redis-stack-server:6.2.6-v9"
+          image: redis/redis-stack-server:6.2.6-v9
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6379
@@ -22,11 +22,11 @@ spec:
               mountPath: /var/lib/redis-stack
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "100m"
+              memory: 256Mi
+              cpu: 100m
             limits:
-              memory: "512Mi"
-              cpu: "500m"
+              memory: 512Mi
+              cpu: 500m
           livenessProbe:
             exec:
               command:

--- a/manifests/base/runner-manager/main/deployment.yaml
+++ b/manifests/base/runner-manager/main/deployment.yaml
@@ -7,23 +7,15 @@ spec:
     spec:
       serviceAccountName: default
       containers:
-        - args:
-            - 'runner_manager.main:app'
-            - '--host'
-            - 0.0.0.0
-            - '--port'
-            - '8000'
-          command:
-            - uvicorn
+        - name: runner-manager
+          image: runner-manager
           env:
             - name: REDIS_OM_URL
               valueFrom:
                 configMapKeyRef:
                   key: REDIS_OM_URL
                   name: redis-config
-          image: runner-manager
           imagePullPolicy: IfNotPresent
-          name: runner-manager
           ports:
             - containerPort: 8000
               name: http


### PR DESCRIPTION
Deployment tests failing with the following error:

```shell
configmap/redis-config-6tc26t8d82 created
service/redis created
service/runner-manager created
deployment.apps/runner-manager-worker created
statefulset.apps/redis created
Error from server (BadRequest): error when creating "STDIN": Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal number into Go struct field Container.spec.template.spec.containers.args of type string
```

Error due to setting `- 0.0.0.0` instead of `- '0.0.0.0'` as args on the container. Fixed it by removing the args/command and using the default values to run the runner-manager API.

Couple of extra changes made along the way while debugging this issue:

- Changed the kustomize image override.
- Added kubernetes vscode extension.
- Small lint/format fix.