### PR TITLE
Remove trusted host middleware

### DIFF
--- a/runner_manager/auth.py
+++ b/runner_manager/auth.py
@@ -1,25 +1,11 @@
 from fastapi import Depends, HTTPException, Security, status
-from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.security import APIKeyHeader, APIKeyQuery
-from starlette.types import Receive, Scope, Send
 
 from runner_manager.dependencies import get_settings
 from runner_manager.models.settings import Settings
 
 api_key_query = APIKeyQuery(name="api-key", auto_error=False)
 api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
-
-
-class TrustedHostHealthRoutes(TrustedHostMiddleware):
-    """A healthcheck endpoint that answers to GET requests on /_health"""
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        """If the request is made on the path _health then execute the check on hosts"""
-        if scope["path"] == "/_health/":
-            print(scope)
-            await super().__call__(scope, receive, send)
-        else:
-            await self.app(scope, receive, send)
 
 
 def get_api_key(

--- a/runner_manager/main.py
+++ b/runner_manager/main.py
@@ -1,35 +1,29 @@
 import logging
 
-from fastapi import Depends, FastAPI
+from fastapi import FastAPI
 from redis import Redis
 from rq import Queue
 
-from runner_manager.auth import TrustedHostHealthRoutes
+from runner_manager import Runner, RunnerGroup, Settings
 from runner_manager.dependencies import get_queue, get_redis, get_settings
 from runner_manager.jobs.startup import startup
-from runner_manager.models.runner import Runner
-from runner_manager.models.runner_group import RunnerGroup
-from runner_manager.models.settings import Settings
 from runner_manager.routers import _health, private, public, webhook
 
 log = logging.getLogger(__name__)
+settings: Settings = get_settings()
+queue: Queue = get_queue()
+redis: Redis = get_redis()
 app = FastAPI()
-settings = get_settings()
 
 
 app.include_router(webhook.router)
 app.include_router(_health.router)
 app.include_router(private.router)
 app.include_router(public.router)
-app.add_middleware(TrustedHostHealthRoutes, allowed_hosts=settings.allowed_hosts)
 
 
 @app.on_event("startup")
-def startup_event(
-    redis: Redis = Depends(get_redis),
-    queue: Queue = Depends(get_queue),
-    settings: Settings = Depends(get_settings),
-):
+def startup_event():
     job = queue.enqueue(startup)
     status = job.get_status()
     Runner.Meta.database = redis

--- a/runner_manager/models/settings.py
+++ b/runner_manager/models/settings.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional
 
 import yaml
 from githubkit import AppInstallationAuthStrategy, TokenAuthStrategy
@@ -36,9 +36,6 @@ class Settings(BaseSettings):
     name: str = "runner-manager"
     redis_om_url: Optional[RedisDsn] = None
     api_key: Optional[SecretStr] = None
-    allowed_hosts: Optional[Sequence[str]] = [
-        "*",
-    ]
     log_level: LogLevel = LogLevel.INFO
     runner_groups: List[BaseRunnerGroup] = []
 


### PR DESCRIPTION
As discussed we are going to handle the healthcheck authorization through the ingress configuration, not exposing the endpoint to the outside world. 