### PR TITLE
healthcheck runner checkup

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2,20 +2,9 @@
 
 echo "Starting runner..."
 echo "RUNNER_ORG: ${RUNNER_ORG}"
-echo "RUNNER_TOKEN: ${RUNNER_TOKEN}"
+echo "RUNNER_JIT_CONFIG: ${RUNNER_JIT_CONFIG}"
 echo "RUNNER_NAME: ${RUNNER_NAME}"
 echo "RUNNER_LABELS: ${RUNNER_LABELS}"
 echo "RUNNER_GROUP: ${RUNNER_GROUP}"
 
-
-./config.sh --url https://github.com/${RUNNER_ORG} \
-    --token "${RUNNER_TOKEN}" \
-    --name "${RUNNER_NAME}" \
-    --labels "${RUNNER_LABELS}" \
-    --runnergroup "${RUNNER_GROUP}" \
-    --work _work \
-    --replace \
-    --unattended \
-    --ephemeral
-
-./run.sh
+./run.sh --jitconfig "${RUNNER_JIT_CONFIG}"

--- a/runner_manager/backend/gcloud.py
+++ b/runner_manager/backend/gcloud.py
@@ -192,8 +192,8 @@ class GCPBackend(BaseBackend):
                 zone=self.config.zone,
                 instance=runner.instance_id or runner.name,
             )
-            instance.labels["status"] = runner.status
-            instance.labels["busy"] = str(runner.busy)
+            instance.labels["status"] = self._sanitize_label_value(runner.status)
+            instance.labels["busy"] = self._sanitize_label_value(str(runner.busy))
 
             log.info(f"Updating {runner.name} labels to {instance.labels}")
             self.client.update(

--- a/runner_manager/backend/gcloud.py
+++ b/runner_manager/backend/gcloud.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 from typing import Dict, List, Literal
 
@@ -178,27 +179,31 @@ class GCPBackend(BaseBackend):
             raise e
         return runners
 
+    def _sanitize_label_value(self, value: str) -> str:
+        value = value[:63]
+        value = value.lower()
+        value = re.sub(r"[^a-z0-9_-]", "-", value)
+        return value
+
     def update(self, runner: Runner) -> Runner:
         try:
             instance: Instance = self.client.get(
                 project=self.config.project_id,
                 zone=self.config.zone,
-                instance=runner.instance_id,
+                instance=runner.instance_id or runner.name,
             )
-            if instance.status != "RUNNING":
-                raise Exception(f"Instance {instance.name} is not running.")
-            labels = {}
-            if runner.labels is not None:
-                labels = {label.name: label.name for label in runner.labels}
-            instance.labels = labels
-            ext_operation: ExtendedOperation = self.client.update(
-                instance_resource=instance
-            )
-            self.wait_for_operation(
+            instance.labels["status"] = runner.status
+            instance.labels["busy"] = str(runner.busy)
+
+            log.info(f"Updating {runner.name} labels to {instance.labels}")
+            self.client.update(
+                instance=runner.instance_id or runner.name,
                 project=self.config.project_id,
                 zone=self.config.zone,
-                operation=ext_operation.name,
+                instance_resource=instance,
             )
+            log.info(f"Updated {runner.name} labels to {instance.labels}")
         except Exception as e:
+            super().update(runner)
             raise e
         return super().update(runner)

--- a/runner_manager/bin/startup.sh
+++ b/runner_manager/bin/startup.sh
@@ -145,8 +145,9 @@ WantedBy=multi-user.target" >/home/actions/actions-runner/bin/actions.runner.ser
 sudo chown -Rh actions:actions /home/actions/actions-runner
 
 if command -v systemctl; then
-	sudo ./svc.sh install
-	sudo ./svc.sh start
+	sudo -H -u actions bash -c 'cd /home/actions/actions-runner &&
+	sudo ./svc.sh install &&
+	sudo ./svc.sh start'
 else
 	nohup /home/actions/actions-runner/run.sh --jitconfig "${RUNNER_JIT_CONFIG}" 2>/home/actions/actions-runner/logs &
 fi

--- a/runner_manager/bin/startup.sh
+++ b/runner_manager/bin/startup.sh
@@ -132,7 +132,7 @@ Description={{Description}}
 After=network.target
 
 [Service]
-ExecStart=/bin/bash {{RunnerRoot}}/runsvc.sh --jitconfig \"$RUNNER_JIT_CONFIG\"
+ExecStart=/bin/bash {{RunnerRoot}}/runsvc.sh --jitconfig \"${RUNNER_JIT_CONFIG}\"
 User={{User}}
 WorkingDirectory={{RunnerRoot}}
 KillMode=process
@@ -148,5 +148,5 @@ if command -v systemctl; then
 	sudo ./svc.sh install
 	sudo ./svc.sh start
 else
-	nohup /home/actions/actions-runner/run.sh --jitconfig "$RUNNER_JIT_CONFIG" 2>/home/actions/actions-runner/logs &
+	nohup /home/actions/actions-runner/run.sh --jitconfig "${RUNNER_JIT_CONFIG}" 2>/home/actions/actions-runner/logs &
 fi

--- a/runner_manager/bin/startup.sh
+++ b/runner_manager/bin/startup.sh
@@ -20,6 +20,7 @@ RUNNER_NAME=${RUNNER_NAME:-$(hostname)}
 RUNNER_ORG=${RUNNER_ORG:-"org"}
 RUNNER_LABELS=${RUNNER_LABELS:-"runner"}
 RUNNER_TOKEN=${RUNNER_TOKEN:-"token"}
+RUNNER_JIT_CONFIG=${RUNNER_JIT_CONFIG:-""}
 RUNNER_GROUP=${RUNNER_GROUP:-"default"}
 RUNNER_WORKDIR=${RUNNER_WORKDIR:-"_work"}
 RUNNER_DOWNLOAD_URL=${RUNNER_DOWNLOAD_URL:-"https://github.com/actions/runner/releases/download/v2.308.0/actions-runner-linux-x64-2.308.0.tar.gz"}
@@ -131,7 +132,7 @@ Description={{Description}}
 After=network.target
 
 [Service]
-ExecStart=/bin/bash {{RunnerRoot}}/runsvc.sh
+ExecStart=/bin/bash {{RunnerRoot}}/runsvc.sh --jitconfig \"$RUNNER_JIT_CONFIG\"
 User={{User}}
 WorkingDirectory={{RunnerRoot}}
 KillMode=process
@@ -142,20 +143,10 @@ TimeoutStopSec=5min
 WantedBy=multi-user.target" >/home/actions/actions-runner/bin/actions.runner.service.template
 
 sudo chown -Rh actions:actions /home/actions/actions-runner
-sudo -u actions /home/actions/actions-runner/config.sh \
-	--url "https://github.com/${RUNNER_ORG}" \
-	--token "${RUNNER_TOKEN}" \
-	--name "${RUNNER_NAME}" \
-	--work "${RUNNER_WORKDIR}" \
-	--labels "${RUNNER_LABELS}" \
-	--runnergroup "${RUNNER_GROUP}" \
-	--replace \
-	--unattended \
-	--ephemeral
 
 if command -v systemctl; then
 	sudo ./svc.sh install
 	sudo ./svc.sh start
 else
-	nohup /home/actions/actions-runner/run.sh 2>/home/actions/actions-runner/logs &
+	nohup /home/actions/actions-runner/run.sh --jitconfig "$RUNNER_JIT_CONFIG" 2>/home/actions/actions-runner/logs &
 fi

--- a/runner_manager/jobs/workflow_job.py
+++ b/runner_manager/jobs/workflow_job.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from githubkit import Response
-from githubkit.rest.models import AuthenticationToken
 from githubkit.webhooks.models import (
     WorkflowJobCompleted,
     WorkflowJobInProgress,

--- a/runner_manager/jobs/workflow_job.py
+++ b/runner_manager/jobs/workflow_job.py
@@ -51,11 +51,6 @@ def queued(webhook: WorkflowJobQueued) -> str | None:
     log.info(f"Found runner group {runner_group.name}")
     log.info(f"Creating registration token for runner {runner_group.name}")
     github: GitHub = get_github()
-    org = runner_group.organization
-    token_response: Response[
-        AuthenticationToken
-    ] = github.rest.actions.create_registration_token_for_org(org=org)
-    token: AuthenticationToken = token_response.parsed_data
     log.info("Registration token created.")
-    runner: Runner = runner_group.create_runner(token)
-    return runner.pk
+    runner: Runner | None = runner_group.create_runner(github)
+    return runner.pk if runner else None

--- a/runner_manager/models/backend.py
+++ b/runner_manager/models/backend.py
@@ -33,7 +33,7 @@ class RunnerEnv(BaseModel):
 
     RUNNER_NAME: Optional[str] = None
     RUNNER_LABELS: Optional[str] = None
-    RUNNER_TOKEN: Optional[str] = None
+    RUNNER_JIT_CONFIG: Optional[str] = None
     RUNNER_ORG: Optional[str] = None
     RUNNER_GROUP: Optional[str] = None
 
@@ -46,7 +46,7 @@ class InstanceConfig(BaseModel):
         return RunnerEnv(
             RUNNER_NAME=runner.name,
             RUNNER_LABELS=",".join([label.name for label in runner.labels]),
-            RUNNER_TOKEN=runner.token,
+            RUNNER_JIT_CONFIG=runner.encoded_jit_config,
             RUNNER_ORG=runner.organization,
             RUNNER_GROUP=runner.runner_group_name,
         )

--- a/runner_manager/models/runner.py
+++ b/runner_manager/models/runner.py
@@ -59,9 +59,7 @@ class Runner(BaseModel):
         default=None,
     )
     token: Optional[str] = None
-    encoded_jit_config: Optional[str] = Field(
-        default=None, description="Encoded JIT config"
-    )
+    encoded_jit_config: Optional[str] = None
     backend: Optional[str] = Field(index=True, description="Backend type")
     status: RunnerStatus = Field(
         default=RunnerStatus.offline, index=True, full_text_search=True

--- a/runner_manager/models/runner_group.py
+++ b/runner_manager/models/runner_group.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 import redis
 from githubkit import Response
 from githubkit.exception import RequestFailed
-from githubkit.rest.models import Runner as GitHubRunner
 from githubkit.webhooks.models import WorkflowJobInProgress
 from githubkit.webhooks.types import WorkflowJobEvent
 from pydantic import BaseModel as PydanticBaseModel

--- a/runner_manager/models/runner_group.py
+++ b/runner_manager/models/runner_group.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 import redis
 from githubkit import Response
 from githubkit.exception import RequestFailed
-from githubkit.rest.models import AuthenticationToken
 from githubkit.rest.models import Runner as GitHubRunner
 from githubkit.webhooks.models import WorkflowJobInProgress
 from githubkit.webhooks.types import WorkflowJobEvent
@@ -110,19 +109,18 @@ class RunnerGroup(BaseModel, BaseRunnerGroup):
             pass
         return runners
 
-    def create_runner(self, token: AuthenticationToken) -> Runner | None:
+    def create_runner(self, github: GitHub) -> Runner | None:
         """Create a runner instance.
 
         Returns:
             Runner: Runner instance.
         """
         count = len(self.get_runners())
-        if count < self.max:
+        if count < self.max and self.id:
             runner: Runner = Runner(
                 name=self.generate_runner_name(),
                 organization=self.organization,
                 status=RunnerStatus.offline,
-                token=token.token,
                 busy=False,
                 runner_group_id=self.id,
                 created_at=datetime.now(),
@@ -130,7 +128,9 @@ class RunnerGroup(BaseModel, BaseRunnerGroup):
                 labels=self.runner_labels,
                 manager=self.manager,
             )
-            runner = runner.save()
+            runner.save()
+            runner.generate_jit_config(github)
+
             return self.backend.create(runner)
         return None
 
@@ -246,26 +246,13 @@ class RunnerGroup(BaseModel, BaseRunnerGroup):
         """Healthcheck runner group."""
         runners = self.get_runners()
         for runner in runners:
-
-            if runner.id is not None:
-                github_runner: GitHubRunner = (
-                    github.rest.actions.get_self_hosted_runner_for_org(
-                        self.organization, runner.id
-                    ).parsed_data
-                )
-                runner = runner.update_status(github_runner)
+            runner.update_from_github(github)
             if runner.time_to_live_expired(time_to_live):
                 self.delete_runner(runner)
             if runner.time_to_start_expired(timeout_runner):
                 self.delete_runner(runner)
         while self.need_new_runner:
-            token_response: Response[
-                AuthenticationToken
-            ] = github.rest.actions.create_registration_token_for_org(
-                org=self.organization
-            )
-            token: AuthenticationToken = token_response.parsed_data
-            runner: Runner = self.create_runner(token)
+            runner: Runner = self.create_runner(github)
             if runner:
                 log.info(f"Runner {runner.name} created")
 

--- a/runner_manager/models/runner_group.py
+++ b/runner_manager/models/runner_group.py
@@ -160,7 +160,10 @@ class RunnerGroup(BaseModel, BaseRunnerGroup):
 
     @property
     def need_new_runner(self) -> bool:
-        return len(self.get_runners()) < (self.min or 0)
+        runners = self.get_runners()
+        idle = len([runner for runner in runners if runner.busy is False])
+        count = len(runners)
+        return idle < self.min and count < self.max
 
     def create_github_group(self, github: GitHub) -> GitHubRunnerGroup:
         """Create a GitHub runner group."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -56,13 +56,3 @@ def runner(settings) -> Runner:
     assert runner.Meta.global_key_prefix == settings.name
     Runner.delete_many(Runner.find().all())
     return runner
-
-
-@fixture()
-def runner_token(runner_group: RunnerGroup, github: GitHub) -> AuthenticationToken:
-    token: Response[
-        AuthenticationToken
-    ] = github.rest.actions.create_registration_token_for_org(
-        org=runner_group.organization
-    )
-    return token.parsed_data

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,14 +1,12 @@
 from datetime import timedelta
 
 import httpx
-from githubkit import Response
 from githubkit.config import Config
-from githubkit.rest.models import AuthenticationToken
 from hypothesis import HealthCheck
 from hypothesis import settings as hypothesis_settings
 from pytest import fixture
 
-from runner_manager import Runner, RunnerGroup
+from runner_manager import Runner
 from runner_manager.clients.github import GitHub
 from runner_manager.models.runner import RunnerLabel
 

--- a/tests/unit/jobs/test_healthchecks.py
+++ b/tests/unit/jobs/test_healthchecks.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 
-from githubkit.rest.models import AuthenticationToken
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from redis_om import Migrator
@@ -44,16 +43,16 @@ def test_healthchecks_hypothesis(
 
 
 def test_group_healthcheck(
-    runner_group: RunnerGroup, settings: Settings, github: GitHub, runner_token
+    runner_group: RunnerGroup, settings: Settings, github: GitHub
 ):
     runner_group.save(github=github)
-    runner_tts: Runner = runner_group.create_runner(runner_token)
+    runner_tts: Runner = runner_group.create_runner(github)
     assert runner_tts is not None
     runner_tts.created_at = datetime.now() - (
         settings.timeout_runner + timedelta(minutes=1)
     )
     runner_tts.save()
-    runner_ttl: Runner = runner_group.create_runner(runner_token)
+    runner_ttl: Runner = runner_group.create_runner(github)
     assert runner_ttl is not None
     runner_ttl.status = RunnerStatus.online
     runner_ttl.started_at = datetime.now() - (
@@ -100,17 +99,17 @@ def test_time_to_live(runner: Runner, settings: Settings):
     assert runner.time_to_live_expired(settings.time_to_live) is False
 
 
-def test_need_new_runner(runner_group: RunnerGroup, runner_token: AuthenticationToken):
+def test_need_new_runner(runner_group: RunnerGroup, github: GitHub):
     runner_group.max = 2
     runner_group.min = 1
     runner_group.save()
     assert runner_group.need_new_runner is True
-    runner_group.create_runner(runner_token)
+    runner_group.create_runner(github)
     assert runner_group.need_new_runner is False
 
 
 def test_healthcheck_job(
-    runner_group: RunnerGroup, settings: Settings, queue: Queue, runner_token
+    runner_group: RunnerGroup, settings: Settings, queue: Queue, github: GitHub
 ):
     runner_group.save()
     queue.enqueue(
@@ -120,7 +119,7 @@ def test_healthcheck_job(
         settings.timeout_runner,
     )
     assert len(runner_group.get_runners()) == 0
-    runner_group.create_runner(runner_token)
+    runner_group.create_runner(github)
     queue.enqueue(
         healthcheck.group,
         runner_group.pk,

--- a/tests/unit/jobs/test_startup.py
+++ b/tests/unit/jobs/test_startup.py
@@ -1,11 +1,12 @@
 from rq import Queue
 from rq.job import Job, JobStatus
 
-from runner_manager import Runner, RunnerGroup
+from runner_manager import Runner, RunnerGroup, Settings
+from runner_manager.clients.github import GitHub
 from runner_manager.jobs.startup import startup
 
 
-def test_startup(queue: Queue, settings, runner_token):
+def test_startup(queue: Queue, settings: Settings, github: GitHub):
     job: Job = queue.enqueue(startup, settings)
     status: JobStatus = job.get_status()
     assert status == JobStatus.FINISHED
@@ -32,7 +33,7 @@ def test_startup(queue: Queue, settings, runner_token):
         backend={"name": "base"},
     )
     runner_group.save()
-    runner_group.create_runner(runner_token)
+    runner_group.create_runner(github)
     runners = Runner.find().count()
     assert RunnerGroup.find().count() == 2
     job: Job = queue.enqueue(startup, settings)

--- a/tests/unit/jobs/test_workflow_job.py
+++ b/tests/unit/jobs/test_workflow_job.py
@@ -30,8 +30,8 @@ from ...strategies import (
 
 def wait_for_migration(model: JsonModel):
     count = 0
+    print("waiting for index to be created")
     while model.find().count() == 0:
-        print("waiting for index to be created")
         sleep(0.1)
         count += 1
         if count > 100:
@@ -163,6 +163,7 @@ def test_workflow_job_queued(
     init_model(RunnerGroup, redis, settings)
     assert webhook.organization
     runner_group: RunnerGroup = RunnerGroup(
+        id=1,
         organization=webhook.organization.login,
         name=f"queued-{uuid4().hex.lower()}",
         labels=webhook.workflow_job.labels,

--- a/tests/unit/models/test_runner_group.py
+++ b/tests/unit/models/test_runner_group.py
@@ -1,5 +1,4 @@
 import pytest
-from githubkit.rest.models import AuthenticationToken
 from githubkit.webhooks.models import WorkflowJobCompleted
 from hypothesis import given
 from pydantic import ValidationError

--- a/tests/unit/models/test_runner_group.py
+++ b/tests/unit/models/test_runner_group.py
@@ -46,20 +46,18 @@ def test_runner_group_backend(runner_group: RunnerGroup):
     RunnerGroup.delete(runner_group.pk)
 
 
-def test_create_runner_from_group(
-    runner_group: RunnerGroup, runner_token: AuthenticationToken
-):
+def test_create_runner_from_group(runner_group: RunnerGroup, github: GitHub):
     runner_group.save()
-    runner = runner_group.create_runner(runner_token)
+    runner = runner_group.create_runner(github)
     assert runner.runner_group_id == runner_group.id
     assert runner.labels == runner_group.runner_labels
+    assert runner.id is not None
+    assert runner.encoded_jit_config is not None
 
 
-def test_list_runners_from_group(
-    runner_group: RunnerGroup, runner_token: AuthenticationToken
-):
+def test_list_runners_from_group(runner_group: RunnerGroup, github: GitHub):
     runner_group.save()
-    runner = runner_group.create_runner(runner_token)
+    runner = runner_group.create_runner(github)
     assert runner in runner_group.get_runners()
 
 
@@ -86,9 +84,7 @@ def test_find_from_webhook(runner_group: RunnerGroup, webhook: WorkflowJobComple
     assert RunnerGroup.find_from_webhook(webhook) is None
 
 
-def test_runner_group_delete_method(
-    runner_group: RunnerGroup, github: GitHub, runner_token
-):
+def test_runner_group_delete_method(runner_group: RunnerGroup, github: GitHub):
     runner_group.id = None
     assert runner_group.default is False
     runner_group.save(github=github)
@@ -96,7 +92,7 @@ def test_runner_group_delete_method(
     runner_group.default = True
     runner_group.save(github=github)
     assert runner_group.default is True
-    runner: Runner = runner_group.create_runner(runner_token)
+    runner: Runner = runner_group.create_runner(github)
     assert runner.runner_group_id == runner_group.id
     assert runner.runner_group_name == runner_group.name
     Migrator().run()
@@ -145,17 +141,17 @@ def test_runner_group_name():
             )
 
 
-def test_need_new_runner(runner_group: RunnerGroup, runner_token: AuthenticationToken):
+def test_need_new_runner(runner_group: RunnerGroup, github: GitHub):
     runner_group.min = 1
     runner_group.max = 2
     runner_group.save()
     assert runner_group.need_new_runner is True
-    runner = runner_group.create_runner(runner_token)
+    runner = runner_group.create_runner(github)
     assert runner is not None
     assert runner_group.need_new_runner is False
     runner.status = RunnerStatus.online
     runner.busy = True
     runner.save()
     assert runner_group.need_new_runner is True
-    runner_group.create_runner(runner_token)
+    runner_group.create_runner(github)
     assert runner_group.need_new_runner is False


### PR DESCRIPTION
The healthcheck function would check if runner.id is defined in order to retrieve its state from github.

The problem with that is that unless the runner has started a job, we would never retrieve its id, so idle runner would never be able to get an updated status and be forever considered as offline by the runner manager.

To fix this issue, we are using another endpoint to create the registration token for runners, which allow us to specify the full runner configuration as well as retrieve the id that will be given.
Thanks to this change we will always have an `runner.id` to work with.