### PR TITLE
PTFE-864 Ensure datetimes are compared with timezones

### DIFF
--- a/runner_manager/models/runner.py
+++ b/runner_manager/models/runner.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Dict, List, Literal, Optional
 
@@ -130,7 +130,7 @@ class Runner(BaseModel):
             datetime: Time since the runner was created
         """
         if self.created_at:
-            now = datetime.now()
+            now = datetime.now(timezone.utc)
             return now - self.created_at
         return timedelta()
 
@@ -143,7 +143,7 @@ class Runner(BaseModel):
             datetime: Time since the runner was updated
         """
         if self.started_at:
-            now = datetime.now()
+            now = datetime.now(timezone.utc)
             return now - self.started_at
         return timedelta()
 
@@ -199,7 +199,7 @@ class Runner(BaseModel):
             Runner: Runner instance.
         """
         if self.created_at is None:
-            self.created_at = datetime.now()
+            self.created_at = datetime.now(timezone.utc)
         return super().save(pipeline=pipeline)
 
 

--- a/runner_manager/models/runner_group.py
+++ b/runner_manager/models/runner_group.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, List, Optional, Self, Union
 from uuid import uuid4
 
@@ -138,7 +138,7 @@ class RunnerGroup(BaseModel, BaseRunnerGroup):
                 status=RunnerStatus.offline,
                 busy=False,
                 runner_group_id=self.id,
-                created_at=datetime.now(),
+                created_at=datetime.now(timezone.utc),
                 runner_group_name=self.name,
                 labels=self.runner_labels,
                 manager=self.manager,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,5 @@
 from base64 import b64encode
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import httpx
 from githubkit.config import Config
@@ -47,6 +47,7 @@ def runner(settings) -> Runner:
         id=1,
         name="test",
         organization="octo-org",
+        created_at=datetime.now(timezone.utc),
         runner_group_id=1,
         status="offline",
         busy=False,

--- a/tests/unit/jobs/test_healthchecks.py
+++ b/tests/unit/jobs/test_healthchecks.py
@@ -102,12 +102,16 @@ def test_time_to_start(runner: Runner, settings: Settings):
 
 def test_time_to_live(runner: Runner, settings: Settings):
     assert settings.time_to_live
-    runner.started_at = datetime.now(timezone.utc) - (settings.time_to_live + timedelta(minutes=1))
+    runner.started_at = datetime.now(timezone.utc) - (
+        settings.time_to_live + timedelta(minutes=1)
+    )
     runner.status = RunnerStatus.online
     runner.busy = True
     assert runner.time_to_live_expired(settings.time_to_live) is True
 
-    runner.started_at = datetime.now(timezone.utc) - (settings.time_to_live - timedelta(minutes=1))
+    runner.started_at = datetime.now(timezone.utc) - (
+        settings.time_to_live - timedelta(minutes=1)
+    )
     assert runner.time_to_live_expired(settings.time_to_live) is False
 
 

--- a/tests/unit/jobs/test_healthchecks.py
+++ b/tests/unit/jobs/test_healthchecks.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -52,7 +52,7 @@ def test_group_healthcheck(
 
     runner_tts: Runner = runner_group.create_runner(github)
     assert runner_tts is not None
-    runner_tts.created_at = datetime.now() - (
+    runner_tts.created_at = datetime.now(timezone.utc) - (
         settings.timeout_runner + timedelta(minutes=1)
     )
     # Removing id to avoid retrieving info from GitHub mock API
@@ -64,7 +64,7 @@ def test_group_healthcheck(
     runner_ttl.id = None
     runner_ttl.status = RunnerStatus.online
     runner_ttl.busy = True
-    runner_ttl.started_at = datetime.now() - (
+    runner_ttl.started_at = datetime.now(timezone.utc) - (
         settings.time_to_live + timedelta(minutes=1)
     )
     runner_ttl.save()
@@ -88,13 +88,13 @@ def test_need_new_runner_healthcheck(
 
 
 def test_time_to_start(runner: Runner, settings: Settings):
-    runner.created_at = datetime.now() - (
+    runner.created_at = datetime.now(timezone.utc) - (
         settings.timeout_runner + timedelta(minutes=1)
     )
     runner.status = RunnerStatus.offline
     assert runner.time_to_start_expired(timeout=settings.timeout_runner) is True
 
-    runner.created_at = datetime.now() - (
+    runner.created_at = datetime.now(timezone.utc) - (
         settings.timeout_runner - timedelta(minutes=1)
     )
     assert runner.time_to_start_expired(timeout=settings.timeout_runner) is False
@@ -102,12 +102,12 @@ def test_time_to_start(runner: Runner, settings: Settings):
 
 def test_time_to_live(runner: Runner, settings: Settings):
     assert settings.time_to_live
-    runner.started_at = datetime.now() - (settings.time_to_live + timedelta(minutes=1))
+    runner.started_at = datetime.now(timezone.utc) - (settings.time_to_live + timedelta(minutes=1))
     runner.status = RunnerStatus.online
     runner.busy = True
     assert runner.time_to_live_expired(settings.time_to_live) is True
 
-    runner.started_at = datetime.now() - (settings.time_to_live - timedelta(minutes=1))
+    runner.started_at = datetime.now(timezone.utc) - (settings.time_to_live - timedelta(minutes=1))
     assert runner.time_to_live_expired(settings.time_to_live) is False
 
 

--- a/tests/unit/models/test_runner.py
+++ b/tests/unit/models/test_runner.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import pytest
 from githubkit.webhooks.models import WorkflowJobCompleted
 from hypothesis import given
@@ -67,3 +69,11 @@ def test_update_from_github(runner: Runner, github: GitHub):
     runner.update_from_github(github, headers={"Prefer": "code=404"})
     assert runner.status == "offline"
     assert runner.busy is False
+
+
+def test_runner_timezone(runner: Runner):
+    runner.started_at = datetime.now(timezone.utc)
+    assert runner.created_at is not None
+    assert runner.created_at.tzinfo == timezone.utc
+    assert runner.started_at.tzinfo == timezone.utc
+    assert runner.time_since_created > runner.time_since_started

--- a/tests/unit/models/test_runner_group.py
+++ b/tests/unit/models/test_runner_group.py
@@ -1,3 +1,5 @@
+from datetime import timezone
+
 import pytest
 from githubkit.webhooks.models import WorkflowJobCompleted
 from hypothesis import given
@@ -48,10 +50,13 @@ def test_runner_group_backend(runner_group: RunnerGroup):
 def test_create_runner_from_group(runner_group: RunnerGroup, github: GitHub):
     runner_group.save()
     runner = runner_group.create_runner(github)
+    assert runner is not None
     assert runner.runner_group_id == runner_group.id
     assert runner.labels == runner_group.runner_labels
     assert runner.id is not None
     assert runner.encoded_jit_config is not None
+    assert runner.created_at is not None
+    assert runner.created_at.tzinfo == timezone.utc
 
 
 def test_list_runners_from_group(runner_group: RunnerGroup, github: GitHub):


### PR DESCRIPTION
Now generating datetime with utc as timezone.

Using `datetime.now(timezone.utc)` instead of `datetime.utcnow()` as with `utcnow` the `tzinfo` remains `None` and is not able to compare datetimes that comes from GitHub's API which explicitly contain offset information.