### PR TITLE
PTFE-742 cannot store redhat password as secretstr

### DIFF
--- a/runner_manager/models/backend.py
+++ b/runner_manager/models/backend.py
@@ -17,7 +17,7 @@ from mypy_boto3_ec2.type_defs import (
     TagSpecificationTypeDef,
     TagTypeDef,
 )
-from pydantic import BaseModel, BaseSettings, SecretStr
+from pydantic import BaseModel, BaseSettings
 
 from runner_manager.bin import startup_sh
 from runner_manager.models.runner import Runner
@@ -54,10 +54,9 @@ class InstanceConfig(BaseSettings):
 
     startup_script: str = startup_sh.as_posix()
     redhat_username: Optional[str]
-    redhat_password: Optional[SecretStr]
+    redhat_password: Optional[str]
 
     def runner_env(self, runner: Runner) -> RunnerEnv:
-
         return RunnerEnv(
             RUNNER_NAME=runner.name,
             RUNNER_LABELS=",".join([label.name for label in runner.labels]),
@@ -66,7 +65,7 @@ class InstanceConfig(BaseSettings):
             RUNNER_GROUP=runner.runner_group_name,
             RUNNER_DOWNLOAD_URL=runner.download_url,
             RUNNER_REDHAT_USERNAME=self.redhat_username,
-            RUNNER_REDHAT_PASSWORD=self.redhat_password.get_secret_value()
+            RUNNER_REDHAT_PASSWORD=self.redhat_password
             if self.redhat_password
             else None,
         )

--- a/tests/unit/backend/test_base.py
+++ b/tests/unit/backend/test_base.py
@@ -45,7 +45,7 @@ def test_setup_redhat_credentials(runner, monkeypatch):
     instance = InstanceConfig()
     assert instance.redhat_username == "username"
     assert instance.redhat_password is not None
-    assert instance.redhat_password.get_secret_value() == "password"
+    assert instance.redhat_password == "password"
     # Test loading from a runnerGroup object
     runner_group: RunnerGroup = RunnerGroup(
         name="test",
@@ -53,13 +53,14 @@ def test_setup_redhat_credentials(runner, monkeypatch):
         organization="octo-org",
         labels=["label"],
     )
+    runner_group.save()
+
+    # Test the remaining config when the group is retrieved from the database
+    runner_group = RunnerGroup.get(runner_group.pk)
     assert runner_group.backend.instance_config
     assert runner_group.backend.instance_config.redhat_username == "username"
     assert runner_group.backend.instance_config.redhat_password is not None
-    assert (
-        runner_group.backend.instance_config.redhat_password.get_secret_value()
-        == "password"
-    )
+    assert runner_group.backend.instance_config.redhat_password == "password"
     # Ensure that the template is rendered correctly
     template = runner_group.backend.instance_config.template_startup(runner)
     assert 'REDHAT_USERNAME="username"' in template

--- a/tests/unit/models/test_settings.py
+++ b/tests/unit/models/test_settings.py
@@ -77,10 +77,7 @@ def test_redhat_credentials(config_file, monkeypatch):
         settings.runner_groups[0].backend.instance_config.redhat_username == "username"
     )
     assert (
-        settings.runner_groups[
-            0
-        ].backend.instance_config.redhat_password.get_secret_value()
-        == "password"
+        settings.runner_groups[0].backend.instance_config.redhat_password == "password"
     )
 
 


### PR DESCRIPTION
var of type `SecretStr` are being stored as `*****` in redis with [redis-om](https://github.com/redis/redis-om-python). Leaving us unable to retrieve the proper password when the group is retrieved from the database and not from the settings configuration in the code.

Now defining the var as `str` until we find a proper solution to the issue.