### PR TITLE
fix assertion error due to incorrect type assumption in webhook timestamp

### DIFF
--- a/runner_manager/jobs/workflow_job.py
+++ b/runner_manager/jobs/workflow_job.py
@@ -34,9 +34,20 @@ def log_workflow_job(webhook: WorkflowJobEvent) -> None:
 def time_to_start(webhook: WorkflowJobEvent) -> timedelta:
     """From a given webhook, calculate the time it took to start the job"""
 
-    assert isinstance(webhook.workflow_job.started_at, datetime)
-    assert isinstance(webhook.workflow_job.created_at, datetime)
-    return webhook.workflow_job.started_at - webhook.workflow_job.created_at
+    if isinstance(webhook.workflow_job.created_at, str):
+        created_at = datetime.fromisoformat(webhook.workflow_job.created_at)
+    else:
+        created_at = webhook.workflow_job.created_at
+
+    if isinstance(webhook.workflow_job.started_at, str):
+        started_at = datetime.fromisoformat(webhook.workflow_job.started_at)
+    else:
+        started_at = webhook.workflow_job.started_at
+
+    assert isinstance(started_at, datetime)
+    assert isinstance(created_at, datetime)
+
+    return started_at - created_at
 
 
 def completed(webhook: WorkflowJobCompleted) -> int:


### PR DESCRIPTION
Following #555, an assertion error was occuring due to the assumption that both the `created_at` and `started_at` fields in the `workflow_job` webhooks were `datetime` instead of `str`.  This, following the pattern in #555, converts the `str` value of the webhook into `datetime` before the assertion.