### PR TITLE
docs: include mermaid.js library

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,10 +56,17 @@ markdown_extensions:
       emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_div_format
   - tables
   - attr_list
   - md_in_html
   - meta
   - admonition
   - pymdownx.details
+
+extra_javascript:
+  - https://unpkg.com/mermaid@10.9.0/dist/mermaid.min.js


### PR DESCRIPTION
Adds the minified mermaid.js library to the mkdocs `extra_javascript`.

Inspired by a comment on the original [feature request at mkdocs-material](https://github.com/squidfunk/mkdocs-material/issues/693#issuecomment-411885426) for mermaid support.

Using the [extra_javascript](https://mkdocs.readthedocs.io/en/859/user-guide/configuration/#extra_javascript) feature to include the minified mermaid.js library from https://unpkg.com/browse/mermaid@10.9.0/dist/

Resolves: #567 