### PR TITLE
fix(poetry): error in devcontainer command

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -63,7 +63,7 @@
     }
   },
   "remoteUser": "vscode",
-  "postCreateCommand": "poetry install --no-interaction --no-ansi --no-root --group=docs --group=dev",
+  "postCreateCommand": "poetry install --no-interaction --no-ansi --no-root --with docs,dev",
   "postAttachCommand": {},
   "portsAttributes": {
     "6379": {


### PR DESCRIPTION
Use the `--with` option from [poetry install](https://python-poetry.org/docs/cli/#install) to install dependency groups instead of `--group`.

This fixes an error shown on VSCode startup when using the devcontainer:
```
Running the postCreateCommand from devcontainer.json...

[98026 ms] Start: Run in container: /bin/sh -c poetry install --no-interaction --no-ansi --no-root --group=docs --group=dev
Creating virtualenv runner-manager in /workspaces/runner-manager/.venv

The option "--group" does not exist
[101878 ms] postCreateCommand failed with exit code 1. Skipping any further user-provided commands.
Done. Press any key to close the terminal.
```




