### PR TITLE
fix(docs): deprecation warning in mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,8 +52,8 @@ markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences


### PR DESCRIPTION
Address deprecation warning when running `poetry run mkdocs build --strict`.

From the upstream [mkdocs-material emoji documentation](https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/?h=material+emoji#configuration):
```
  - pymdownx.emoji:
      emoji_index: !!python/name:material.extensions.emoji.twemoji
      emoji_generator: !!python/name:material.extensions.emoji.to_svg
```
