### PR TITLE
aws: add support for instance profiles

### DIFF
--- a/runner_manager/models/backend.py
+++ b/runner_manager/models/backend.py
@@ -152,7 +152,7 @@ class AWSInstanceConfig(InstanceConfig):
     tags: Dict[str, str] = {}
     volume_type: VolumeTypeType = "gp3"
     disk_size_gb: int = 20
-    iam_instance_profile_name: Optional[str] = ""
+    iam_instance_profile_arn: str = ""
 
     def configure_instance(self, runner: Runner) -> AwsInstance:
         """Configure instance."""
@@ -188,7 +188,7 @@ class AWSInstanceConfig(InstanceConfig):
             ),
         ]
         iam_instance_profile: IamInstanceProfileTypeDef = IamInstanceProfileTypeDef(
-            Name=self.iam_instance_profile_name
+            Arn=self.iam_instance_profile_arn
         )
         return AwsInstance(
             ImageId=self.image,

--- a/runner_manager/models/backend.py
+++ b/runner_manager/models/backend.py
@@ -7,9 +7,9 @@ from mypy_boto3_ec2.literals import InstanceTypeType, VolumeTypeType
 from mypy_boto3_ec2.type_defs import (
     BlockDeviceMappingTypeDef,
     EbsBlockDeviceTypeDef,
+    IamInstanceProfileTypeDef,
     TagSpecificationTypeDef,
     TagTypeDef,
-    IamInstanceProfileTypeDef,
 )
 from pydantic import BaseModel, BaseSettings
 
@@ -187,8 +187,9 @@ class AWSInstanceConfig(InstanceConfig):
                 Tags=tags,
             ),
         ]
-        iam_instance_profile: IamInstanceProfileTypeDef = IamInstanceProfileTypeDef(Name=self.iam_instance_profile_name)
-
+        iam_instance_profile: IamInstanceProfileTypeDef = IamInstanceProfileTypeDef(
+            Name=self.iam_instance_profile_name
+        )
         return AwsInstance(
             ImageId=self.image,
             InstanceType=self.instance_type,

--- a/runner_manager/models/backend.py
+++ b/runner_manager/models/backend.py
@@ -9,6 +9,7 @@ from mypy_boto3_ec2.type_defs import (
     EbsBlockDeviceTypeDef,
     TagSpecificationTypeDef,
     TagTypeDef,
+    IamInstanceProfileTypeDef,
 )
 from pydantic import BaseModel, BaseSettings
 
@@ -133,6 +134,7 @@ AwsInstance = TypedDict(
         "BlockDeviceMappings": Sequence[BlockDeviceMappingTypeDef],
         "MaxCount": int,
         "MinCount": int,
+        "IamInstanceProfile": IamInstanceProfileTypeDef,
     },
 )
 
@@ -150,6 +152,7 @@ class AWSInstanceConfig(InstanceConfig):
     tags: Dict[str, str] = {}
     volume_type: VolumeTypeType = "gp3"
     disk_size_gb: int = 20
+    iam_instance_profile_name: Optional[str] = ""
 
     def configure_instance(self, runner: Runner) -> AwsInstance:
         """Configure instance."""
@@ -184,6 +187,8 @@ class AWSInstanceConfig(InstanceConfig):
                 Tags=tags,
             ),
         ]
+        iam_instance_profile: IamInstanceProfileTypeDef = IamInstanceProfileTypeDef(Name=self.iam_instance_profile_name)
+
         return AwsInstance(
             ImageId=self.image,
             InstanceType=self.instance_type,
@@ -194,4 +199,5 @@ class AWSInstanceConfig(InstanceConfig):
             MaxCount=self.max_count,
             MinCount=self.min_count,
             BlockDeviceMappings=block_device_mappings,
+            IamInstanceProfile=iam_instance_profile,
         )

--- a/tests/unit/backend/test_aws.py
+++ b/tests/unit/backend/test_aws.py
@@ -46,11 +46,12 @@ def aws_runner(runner: Runner, aws_group: RunnerGroup) -> Runner:
 def test_aws_instance_config(runner: Runner):
     AWSConfig()
     instance_config = AWSInstanceConfig(
-        tags={"test": "test"}, subnet_id="i-0f9b0a3b7b3b3b3b3"
+        tags={"test": "test"}, subnet_id="i-0f9b0a3b7b3b3b3b3", iam_instance_profile_name = "test"
     )
     instance: AwsInstance = instance_config.configure_instance(runner)
     assert instance["ImageId"] == instance_config.image
     assert instance["SubnetId"] == instance_config.subnet_id
+    assert instance["IamInstanceProfile"]["Name"] == instance_config.iam_instance_profile_name
     assert runner.name in instance["UserData"]
     tags = instance["TagSpecifications"][0]["Tags"]
     assert TagTypeDef(Key="test", Value="test") in tags

--- a/tests/unit/backend/test_aws.py
+++ b/tests/unit/backend/test_aws.py
@@ -46,12 +46,17 @@ def aws_runner(runner: Runner, aws_group: RunnerGroup) -> Runner:
 def test_aws_instance_config(runner: Runner):
     AWSConfig()
     instance_config = AWSInstanceConfig(
-        tags={"test": "test"}, subnet_id="i-0f9b0a3b7b3b3b3b3", iam_instance_profile_name = "test"
+        tags={"test": "test"},
+        subnet_id="i-0f9b0a3b7b3b3b3b3",
+        iam_instance_profile_name="test",
     )
     instance: AwsInstance = instance_config.configure_instance(runner)
     assert instance["ImageId"] == instance_config.image
     assert instance["SubnetId"] == instance_config.subnet_id
-    assert instance["IamInstanceProfile"]["Name"] == instance_config.iam_instance_profile_name
+    assert (
+        instance["IamInstanceProfile"]["Name"]
+        == instance_config.iam_instance_profile_name
+    )
     assert runner.name in instance["UserData"]
     tags = instance["TagSpecifications"][0]["Tags"]
     assert TagTypeDef(Key="test", Value="test") in tags

--- a/tests/unit/backend/test_aws.py
+++ b/tests/unit/backend/test_aws.py
@@ -48,14 +48,14 @@ def test_aws_instance_config(runner: Runner):
     instance_config = AWSInstanceConfig(
         tags={"test": "test"},
         subnet_id="i-0f9b0a3b7b3b3b3b3",
-        iam_instance_profile_name="test",
+        iam_instance_profile_arn="test",
     )
     instance: AwsInstance = instance_config.configure_instance(runner)
     assert instance["ImageId"] == instance_config.image
     assert instance["SubnetId"] == instance_config.subnet_id
     assert (
         instance["IamInstanceProfile"]["Name"]
-        == instance_config.iam_instance_profile_name
+        == instance_config.iam_instance_profile_arn
     )
     assert runner.name in instance["UserData"]
     tags = instance["TagSpecifications"][0]["Tags"]

--- a/tests/unit/backend/test_aws.py
+++ b/tests/unit/backend/test_aws.py
@@ -54,7 +54,7 @@ def test_aws_instance_config(runner: Runner):
     assert instance["ImageId"] == instance_config.image
     assert instance["SubnetId"] == instance_config.subnet_id
     assert (
-        instance["IamInstanceProfile"]["Name"]
+        instance["IamInstanceProfile"]["Arn"]
         == instance_config.iam_instance_profile_arn
     )
     assert runner.name in instance["UserData"]


### PR DESCRIPTION
Currently there is no way of assigning IAM roles to runner instances at creation time. This PR adds an additional field in the AWS backend which creates EC2 instances with the specified `IamInstanceProfile`, configurable by the `iam_instance_profile_arn` field in the `runner-manager.yaml` config.

This implementation only accepts instances profiles by their ARN and not by their name to keep the implementation as simple as possible.