### PR TITLE
webhook: fix non-matching webhook secrets not being rejected

### DIFF
--- a/runner_manager/routers/webhook.py
+++ b/runner_manager/routers/webhook.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Set
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Security, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Security
 from githubkit.versions.latest.models import WebhookPing
 from githubkit.webhooks import verify
 from rq import Queue
@@ -37,7 +37,10 @@ async def validate_webhook(
     )
 
     if not valid:
-      raise HTTPException(status_code=401, detail="Signature values do not match - check webhook secret value")
+        raise HTTPException(
+            status_code=401,
+            detail="Signature values do not match - check webhook secret value",
+        )
 
     return valid
 


### PR DESCRIPTION
Fixes an issue which allowed webhooks to be processed with an incorrect webhook secret. 

This adds a case to return a `401` when the `verify` function returns false. The `verify` function also always returns false as it is being passed in JSON from a `WorkflowJob` webhook object instead of the request body (which is how GitHub generates it's signitures) meaning the signatures will never match (see https://github.com/yanyongyu/githubkit?tab=readme-ov-file#webhook-verification). 