### PR TITLE
api: add endpoint to list runners

### DIFF
--- a/runner_manager/routers/runner_groups.py
+++ b/runner_manager/routers/runner_groups.py
@@ -13,6 +13,7 @@ from runner_manager.jobs.reset import group as group_reset
 from runner_manager.jobs.runner import runner as runner_create
 from runner_manager.jobs.startup import sync_runner_groups
 from runner_manager.models.api import JobResponse
+from runner_manager.models.runner import Runner
 
 router = APIRouter(prefix="/groups")
 
@@ -91,3 +92,14 @@ def create_runner(name: str, queue: Queue = Depends(get_queue)) -> JobResponse:
     else:
         job: Job = queue.enqueue(runner_create, group)
         return JobResponse(id=job.id, status=job.get_status())
+
+
+@router.get("/{name}/list")
+def list_runners(name: str) -> List[Runner]:
+    try:
+        group: RunnerGroup = RunnerGroup.find(RunnerGroup.name == name).first()
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail=f"Runner group {name} not found.")
+    else:
+        runners = group.get_runners()
+        return runners

--- a/tests/api/test_runner_groups_router.py
+++ b/tests/api/test_runner_groups_router.py
@@ -23,6 +23,15 @@ def test_get_group(client: TestClient, runner_group: RunnerGroup):
     runner_group.save()
 
 
+def test_get_group_runners(client: TestClient, runner_group: RunnerGroup):
+    response = client.get(f"/groups/{runner_group.name}/list")
+    assert response.status_code == 404
+    runner_group.save()
+    response = client.get(f"/groups/{runner_group.name}/list")
+    assert response.status_code == 200
+    assert response.json() == runner_group.get_runners()
+
+
 def test_delete_group(client: TestClient, runner_group: RunnerGroup):
     response = client.delete(f"/groups/{runner_group.name}")
     assert response.status_code == 404


### PR DESCRIPTION
Adds an endpoint at `/groups/{name}/list` to list the runners in each runner group .

Relates to #625 