### PR TITLE
Expose os and arch param for BaseRunnerGroup

### DIFF
--- a/runner_manager/models/runner_group.py
+++ b/runner_manager/models/runner_group.py
@@ -43,6 +43,8 @@ class BaseRunnerGroup(PydanticBaseModel):
     runners: Optional[List[int]] = None
     max: Optional[int] = Field(ge=1, default=20)
     min: Optional[int] = Field(ge=0, default=0)
+    os: str = Field(default="linux")
+    arch: str = Field(default="x64")
     labels: List[str]
     job_started_script: Optional[str] = ""
     job_completed_script: Optional[str] = ""


### PR DESCRIPTION
- The config params loaded in [settings](https://github.com/scality/runner-manager/blob/main/runner_manager/models/settings.py#L33) maps to the [BaseRunnerGroup](https://github.com/scality/runner-manager/blob/main/runner_manager/models/runner_group.py#L32) . 
- Added `os` and `arch` params to the BaseRunnerGroup in order to configure them through the config yaml.
- This is required for filtering the [download_url](https://github.com/scality/runner-manager/blob/main/runner_manager/models/runner_group.py#L130)