### PR TITLE
fix: job hook scripts pre-emptively expands shell parameters

### DIFF
--- a/runner_manager/bin/startup.sh
+++ b/runner_manager/bin/startup.sh
@@ -144,11 +144,11 @@ function setup_runner {
 		sudo -H -u actions bash -c "nohup /home/actions/actions-runner/run.sh --jitconfig \"${JIT_CONFIG}\" 2>/home/actions/actions-runner/logs &"
 	fi
 
-	cat <<EOF >/opt/runner/job_started_script.sh
+	cat <<'EOF' >/opt/runner/job_started_script.sh
 ${RUNNER_JOB_STARTED_SCRIPT}
 EOF
 
-	cat <<EOF >/opt/runner/job_completed_script.sh
+	cat <<'EOF' >/opt/runner/job_completed_script.sh
 ${RUNNER_JOB_COMPLETED_SCRIPT}
 EOF
 


### PR DESCRIPTION
The `job_started_script` and `job_completed_script` pre-emptively expand any shell parameters defined in them, resulting in them being expanded when the `/opt/runner/job_started_script.sh` and `/opt/runner/job_completed_script.sh` files are created and not at runtime of the job.

Instructing the heredoc document to skip expanding any shell parameters gives the expected functionality without having to escape them in the config file.