### PR TITLE
(PTFE-2499) Add variable to deploy service systemd

### DIFF
--- a/runner_manager/bin/startup.sh
+++ b/runner_manager/bin/startup.sh
@@ -90,7 +90,8 @@ Description=GitHub Actions Runner
 After=network.target
 
 [Service]
-ExecStart=/bin/bash /home/actions/actions-runner/run.sh --jitconfig \"${JIT_CONFIG}\"
+Environment=\"JIT_BASE64=${JIT_CONFIG}\"
+ExecStart=/bin/bash /home/actions/actions-runner/run.sh --jitconfig \"${JIT_BASE64}\"
 User=actions
 WorkingDirectory=/home/actions/actions-runner
 KillMode=process


### PR DESCRIPTION
Since 18/06/2025 ubuntu runner on Jammy can't launch there systemd service because de base64 $JIT_CONFIG is to large for systemd.

Here we push the base64 in an env var which will be use by the command line.

This type of systemd service has been test both on ubuntu22.04 and ubuntu24